### PR TITLE
Fix VM boot failure due to request arriving before virtio-net initialization

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Architecture & OS
 
 ToyVMM only supports **x86_64** Linux for Guest OS.  
-ToyVMM has been confirmed to work with Rocky Linux 8.6, 9.1 and Ubuntu 18.04 as the Hypervisor OS.  
+ToyVMM has been confirmed to work with Rocky Linux 8.6, 9.1 and Ubuntu 18.04, 22.04 as the Hypervisor OS.  
 
 ## Prerequisites
 

--- a/src/vmm/src/devices/epoll.rs
+++ b/src/vmm/src/devices/epoll.rs
@@ -118,15 +118,10 @@ impl EpollContext {
         let ref mut maybe = self.device_handlers[device_idx];
         match maybe.handler {
             Some(ref mut v) => v.as_mut(),
-            None => {
-                // This should only be called in response to an epoll trigger, and the channel
-                // should always contain a message after the events were added to epoll
-                // by the activate() call
-                maybe
-                    .handler
-                    .get_or_insert(maybe.receiver.try_recv().unwrap())
-                    .as_mut()
-            }
+            None => maybe
+                .handler
+                .get_or_insert(maybe.receiver.recv().unwrap())
+                .as_mut(),
         }
     }
 }

--- a/src/vmm/src/devices/virtio/net.rs
+++ b/src/vmm/src/devices/virtio/net.rs
@@ -147,7 +147,9 @@ impl NetEpollHandler {
                 Ok(count) => {
                     self.rx_count = count;
                     if !self.rx_single_frame() {
-                        println!("differed_rx turn to true");
+                        // DEBUG)  Found that when the Hypervisor OS is Ubuntu 22.04,
+                        //         this process is performed at boot
+                        // println!("differed_rx turn to true");
                         self.deferred_rx = true;
                         break;
                     }


### PR DESCRIPTION
Fixed a case where VM initialization failed due to a request for a network device arriving before virtio-net initialization.

This fix also allows the Hypervisor OS to successfully boot VMs on Ubuntu 22.04.