### PR TITLE
Comply with the Apache-2.0 license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.  
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,12 +52,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-
-[[package]]
-name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
@@ -111,7 +105,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -135,16 +129,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "epoll"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f438f4df5a02309cd0263e944ccc97704968c96b13f634dd4cb83d8e155b83aa"
-dependencies = [
- "bitflags 0.7.0",
- "libc",
 ]
 
 [[package]]
@@ -286,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.42"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -297,22 +281,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -366,7 +350,6 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "derive_more",
- "epoll",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+ToyVMM
+Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Portions Copyright 2017-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the THIRD-PARTY file.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Book ([en](https://aztecher.github.io/en/) / [ja](https://aztecher.github.io/ja/
 As we expand the implementation of ToyVMM, we plan to enhance the contents of the book as well.
 If you find any mistakes or my misunderstandings in the documentation, please feel free to submit an issue to the [toyvmm-book](https://github.com/aztecher/toyvmm-book) repository.
 
-**CHANGE LOG**
+**BOOK CHANGE LOG**
 
 * Dec 27, 2023 : Add contents about SMP only in ja.
 * Sep 24, 2023 : Add 'Virtio' contents and translate all existing contents into ja / en.
@@ -43,8 +43,7 @@ Please see the [quickstart guide](./docs/getting-started.md) to launch your VM u
 ## Features and Capabilities
 
 * Can run a virtual machine!
-* Customizing the memory size of your virtual machine is available.
-  * Currently only one vCPU is supported, but support for multiple vCPUs is planned for implementation.
+* Customizing the number of vCPU and memory size of your virtual machine is available.
 * Support virtio-blk and virtio-net to execute disk and network I/O in virtual machine.
   * Thanks to the virtio-blk, toyvmm can launch the guest OS from rootfs images like ubuntu-18.04.ext4, not only initramfs.
   * Thanks to the virtio-net, the virtual machine can reach out of the host (requires the host-side iptables setting).

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,0 +1,27 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/toyvmm/src/main.rs
+++ b/src/toyvmm/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use clap::{Parser, Subcommand};
 use std::fs::read_to_string;
 use std::path::PathBuf;

--- a/src/toyvmm/src/utils/mod.rs
+++ b/src/toyvmm/src/utils/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use vmm::builder::{build_and_boot_vm, StartVmError};
 use vmm::resources::VmResources;
 

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["aztecher <mikiyaf.business@gmail.com>"]
 description = "ToyVMM is a project being developed for the purpose of learning virtualization technology"
-license = "MIT"
+license = "Apache-2.0"
 
 [lib]
 bench = false

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,3 +1,14 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// We use `utils` as a wrapper over `vmm_sys_util` to control the latter
+// dependency easier (i.e. update only in one place `vmm_sys_util` version).
+// More specifically, we are re-exporting modules from `vmm_sys_util` as part
+// of the `utils` crate.
+
 pub use vmm_sys_util::{
     epoll, errno, eventfd, fam, ioctl, ioctl_ior_nr, ioctl_iow_nr, poll, tempfile, terminal,
 };

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,3 +1,3 @@
 pub use vmm_sys_util::{
-    errno, eventfd, fam, ioctl, ioctl_ior_nr, ioctl_iow_nr, poll, tempfile, terminal,
+    epoll, errno, eventfd, fam, ioctl, ioctl_ior_nr, ioctl_iow_nr, poll, tempfile, terminal,
 };

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -11,7 +11,6 @@ bench = false
 
 [dependencies]
 libc = ">=0.2.80"
-epoll = "=2.1.0"
 scopeguard = "=0.3.3"
 kvm-bindings = { version = ">=0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.11.0"

--- a/src/vmm/src/arch/mod.rs
+++ b/src/vmm/src/arch/mod.rs
@@ -1,1 +1,4 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod x86_64;

--- a/src/vmm/src/arch/x86_64/interrupt.rs
+++ b/src/vmm/src/arch/x86_64/interrupt.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/vmm/src/arch/x86_64/layout.rs
+++ b/src/vmm/src/arch/x86_64/layout.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/vmm/src/arch/x86_64/mod.rs
+++ b/src/vmm/src/arch/x86_64/mod.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/vmm/src/arch/x86_64/msr.rs
+++ b/src/vmm/src/arch/x86_64/msr.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/vmm/src/arch/x86_64/regs.rs
+++ b/src/vmm/src/arch/x86_64/regs.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/vmm/src/arch_gen/mod.rs
+++ b/src/vmm/src/arch_gen/mod.rs
@@ -1,1 +1,4 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod x86;

--- a/src/vmm/src/arch_gen/x86/mod.rs
+++ b/src/vmm/src/arch_gen/x86/mod.rs
@@ -1,1 +1,4 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod mpspec;

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1,3 +1,9 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     arch, cpu,
     device_manager::{

--- a/src/vmm/src/cpu/amd.rs
+++ b/src/vmm/src/cpu/amd.rs
@@ -1,5 +1,9 @@
-// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::{
     common::get_vendor_id_from_host,
     cpuid, cpuid_count,

--- a/src/vmm/src/cpu/common.rs
+++ b/src/vmm/src/cpu/common.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cpuid_count;

--- a/src/vmm/src/cpu/intel.rs
+++ b/src/vmm/src/cpu/intel.rs
@@ -1,3 +1,9 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::{CpuidEntry, CpuidKey, CpuidRegisters, CpuidTrait, KvmCpuidFlags, NormalizeCpuidError};
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/vmm/src/cpu/mod.rs
+++ b/src/vmm/src/cpu/mod.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::devices::{
     bus::{Bus, BusDevice, BusError},
     legacy::{

--- a/src/vmm/src/device_manager/mmio.rs
+++ b/src/vmm/src/device_manager/mmio.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -1,2 +1,5 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod legacy;
 pub mod mmio;

--- a/src/vmm/src/devices/bus.rs
+++ b/src/vmm/src/devices/bus.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.

--- a/src/vmm/src/devices/epoll.rs
+++ b/src/vmm/src/devices/epoll.rs
@@ -5,9 +5,9 @@
 // found in the LICENSE file.
 
 use crate::devices::virtio;
-use epoll;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::mpsc::{channel, Receiver, Sender};
+use utils::epoll;
 
 /// Errors associated with actions on epoll.
 #[derive(Debug, thiserror::Error)]
@@ -51,40 +51,39 @@ impl MaybeHandler {
 //design is the liberal passing around of raw_fds, and duping of file descriptors. This issue
 //will be solved when we also implement device removal.
 pub struct EpollContext {
-    pub epoll_raw_fd: RawFd,
+    pub ep: epoll::Epoll,
     pub dispatch_table: Vec<EpollDispatch>,
     pub device_handlers: Vec<MaybeHandler>,
 }
 
 impl EpollContext {
     pub fn new(exit_evt_raw_fd: RawFd) -> Result<Self, EpollContextError> {
-        let epoll_raw_fd = epoll::create(true).map_err(EpollContextError::Create)?;
+        // let epoll_raw_fd = epoll::create(true).map_err(EpollContextError::Create)?;
+        let epoll_fd = epoll::Epoll::new().map_err(EpollContextError::Create)?;
         // some reasonable initial capacity value
         let mut dispatch_table = Vec::with_capacity(20);
         let device_handlers = Vec::with_capacity(6);
-
-        epoll::ctl(
-            epoll_raw_fd,
-            epoll::EPOLL_CTL_ADD,
-            exit_evt_raw_fd,
-            epoll::Event::new(epoll::EPOLLIN, dispatch_table.len() as u64),
-        )
-        .map_err(EpollContextError::Add)?;
-
+        epoll_fd
+            .ctl(
+                epoll::ControlOperation::Add,
+                exit_evt_raw_fd,
+                epoll::EpollEvent::new(epoll::EventSet::IN, dispatch_table.len() as u64),
+            )
+            .map_err(EpollContextError::Add)?;
         dispatch_table.push(EpollDispatch::Exit);
 
-        epoll::ctl(
-            epoll_raw_fd,
-            epoll::EPOLL_CTL_ADD,
-            libc::STDIN_FILENO,
-            epoll::Event::new(epoll::EPOLLIN, dispatch_table.len() as u64),
-        )
-        .map_err(EpollContextError::Add)?;
+        epoll_fd
+            .ctl(
+                epoll::ControlOperation::Add,
+                libc::STDIN_FILENO,
+                epoll::EpollEvent::new(epoll::EventSet::IN, dispatch_table.len() as u64),
+            )
+            .map_err(EpollContextError::Add)?;
 
         dispatch_table.push(EpollDispatch::Stdin);
 
         Ok(EpollContext {
-            epoll_raw_fd,
+            ep: epoll_fd,
             dispatch_table,
             device_handlers,
         })
@@ -105,12 +104,22 @@ impl EpollContext {
 
     pub fn allocate_virtio_blk_token(&mut self) -> virtio::block::EpollConfig {
         let (dispatch_base, sender) = self.allocate_tokens(2);
-        virtio::block::EpollConfig::new(dispatch_base, self.epoll_raw_fd, sender)
+        let ep_clone = unsafe {
+            let mut clone = std::mem::zeroed::<epoll::Epoll>();
+            std::ptr::copy(&self.ep, &mut clone, 1);
+            clone
+        };
+        virtio::block::EpollConfig::new(dispatch_base, ep_clone, sender)
     }
 
     pub fn allocate_virtio_net_tokens(&mut self) -> virtio::net::EpollConfig {
         let (dispatch_base, sender) = self.allocate_tokens(4);
-        virtio::net::EpollConfig::new(dispatch_base, self.epoll_raw_fd, sender)
+        let ep_clone = unsafe {
+            let mut clone = std::mem::zeroed::<epoll::Epoll>();
+            std::ptr::copy(&self.ep, &mut clone, 1);
+            clone
+        };
+        virtio::net::EpollConfig::new(dispatch_base, ep_clone, sender)
     }
 
     #[allow(clippy::toplevel_ref_arg)]
@@ -128,7 +137,7 @@ impl EpollContext {
 
 impl Drop for EpollContext {
     fn drop(&mut self) {
-        let rc = unsafe { libc::close(self.epoll_raw_fd) };
+        let rc = unsafe { libc::close(self.ep.as_raw_fd()) };
         if rc != 0 {
             println!("warn: cannot close epoll");
         }

--- a/src/vmm/src/devices/epoll.rs
+++ b/src/vmm/src/devices/epoll.rs
@@ -1,6 +1,9 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/vmm/src/devices/legacy/mod.rs
+++ b/src/vmm/src/devices/legacy/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod serial;
 
 use std::io;

--- a/src/vmm/src/devices/legacy/serial.rs
+++ b/src/vmm/src/devices/legacy/serial.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::EventFdTrigger;
 use crate::devices::bus::BusDevice;
 use std::io::Write;

--- a/src/vmm/src/devices/mod.rs
+++ b/src/vmm/src/devices/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod bus;
 pub mod epoll;
 pub mod legacy;

--- a/src/vmm/src/devices/util/mod.rs
+++ b/src/vmm/src/devices/util/mod.rs
@@ -1,6 +1,5 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod net;
 pub mod sys;

--- a/src/vmm/src/devices/util/net/mod.rs
+++ b/src/vmm/src/devices/util/net/mod.rs
@@ -1,1 +1,4 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod tap;

--- a/src/vmm/src/devices/util/net/tap.rs
+++ b/src/vmm/src/devices/util/net/tap.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/vmm/src/devices/util/sys/mod.rs
+++ b/src/vmm/src/devices/util/sys/mod.rs
@@ -1,2 +1,5 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod net;
 pub mod virtio;

--- a/src/vmm/src/devices/util/sys/net/mod.rs
+++ b/src/vmm/src/devices/util/sys/net/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
 // Copyright TUNTAP, 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/src/vmm/src/devices/util/sys/net/tuntap.rs
+++ b/src/vmm/src/devices/util/sys/net/tuntap.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // extern in src/lib.rs
 use super::if_tun::sock_fprog;
 use utils::{ioctl_ior_nr, ioctl_iow_nr};

--- a/src/vmm/src/devices/util/sys/virtio/mod.rs
+++ b/src/vmm/src/devices/util/sys/virtio/mod.rs
@@ -1,1 +1,4 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod net;

--- a/src/vmm/src/devices/virtio/block.rs
+++ b/src/vmm/src/devices/virtio/block.rs
@@ -18,9 +18,9 @@ use std::{
     fs::File,
     io::{Read, Seek, SeekFrom, Write},
     os::linux::fs::MetadataExt,
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::AsRawFd,
 };
-use utils::eventfd::EventFd;
+use utils::{epoll, eventfd::EventFd};
 use vm_memory::{Bytes, GuestAddress, GuestMemory, GuestMemoryError};
 
 const SECTOR_SHIFT: u8 = 9; // 512 = 2^9
@@ -325,20 +325,20 @@ impl EpollHandler for BlockEpollHandler {
 pub struct EpollConfig {
     queue_avail_token: u64,
     kill_token: u64,
-    epoll_raw_fd: RawFd,
+    ep: epoll::Epoll,
     sender: mpsc::Sender<Box<dyn EpollHandler>>,
 }
 
 impl EpollConfig {
     pub fn new(
         first_token: u64,
-        epoll_raw_fd: RawFd,
+        ep: epoll::Epoll,
         sender: mpsc::Sender<Box<dyn EpollHandler>>,
     ) -> Self {
         EpollConfig {
             queue_avail_token: first_token,
             kill_token: first_token + 1,
-            epoll_raw_fd,
+            ep,
             sender,
         }
     }
@@ -531,22 +531,25 @@ impl VirtioDevice for Block {
             // the channel should be open at this point
             self.epoll_config.sender.send(Box::new(handler)).unwrap();
 
-            epoll::ctl(
-                self.epoll_config.epoll_raw_fd,
-                epoll::EPOLL_CTL_ADD,
-                queue_evt_raw_fd,
-                epoll::Event::new(epoll::EPOLLIN, self.epoll_config.queue_avail_token),
-            )
-            .map_err(ActivateError::EpollCtl)?;
-
-            epoll::ctl(
-                self.epoll_config.epoll_raw_fd,
-                epoll::EPOLL_CTL_ADD,
-                kill_evt_raw_fd,
-                epoll::Event::new(epoll::EPOLLIN, self.epoll_config.kill_token),
-            )
-            .map_err(ActivateError::EpollCtl)?;
-
+            self.epoll_config
+                .ep
+                .ctl(
+                    epoll::ControlOperation::Add,
+                    queue_evt_raw_fd,
+                    epoll::EpollEvent::new(
+                        epoll::EventSet::IN,
+                        self.epoll_config.queue_avail_token,
+                    ),
+                )
+                .map_err(ActivateError::EpollCtl)?;
+            self.epoll_config
+                .ep
+                .ctl(
+                    epoll::ControlOperation::Add,
+                    kill_evt_raw_fd,
+                    epoll::EpollEvent::new(epoll::EventSet::IN, self.epoll_config.kill_token),
+                )
+                .map_err(ActivateError::EpollCtl)?;
             return Ok(());
         }
 

--- a/src/vmm/src/devices/virtio/block.rs
+++ b/src/vmm/src/devices/virtio/block.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/vmm/src/devices/virtio/mmio.rs
+++ b/src/vmm/src/devices/virtio/mmio.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/vmm/src/devices/virtio/mod.rs
+++ b/src/vmm/src/devices/virtio/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod block;
 pub mod mmio;
 pub mod net;

--- a/src/vmm/src/devices/virtio/net.rs
+++ b/src/vmm/src/devices/virtio/net.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -16,7 +19,6 @@ use crate::devices::{
     },
 };
 use crate::vstate::memory::GuestMemoryMmap;
-// use epoll;
 use std::io::{Read, Write};
 use std::mem;
 use std::os::unix::io::AsRawFd;

--- a/src/vmm/src/devices/virtio/queue.rs
+++ b/src/vmm/src/devices/virtio/queue.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/vmm/src/devices/virtio/status.rs
+++ b/src/vmm/src/devices/virtio/status.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // [Device Status Field](https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-110001)
 pub const ACKNOWLEDGE: u32 = 0x01;
 pub const DRIVER: u32 = 0x02;

--- a/src/vmm/src/devices/virtio/types.rs
+++ b/src/vmm/src/devices/virtio/types.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // [Device Type](https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.html#x1-2160005)
 pub const NETWORK_CARD: u32 = 0x01;
 pub const BLOCK_DEVICE: u32 = 0x02;

--- a/src/vmm/src/devices/virtio/virtio_device.rs
+++ b/src/vmm/src/devices/virtio/virtio_device.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -1,3 +1,13 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
 pub mod arch;
 pub mod arch_gen;
 pub mod builder;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -1,3 +1,9 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::vmm_config::boot_source::{

--- a/src/vmm/src/utils/byte_order.rs
+++ b/src/vmm/src/utils/byte_order.rs
@@ -1,4 +1,7 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 macro_rules! generate_read_fn {

--- a/src/vmm/src/utils/memory.rs
+++ b/src/vmm/src/utils/memory.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::os::unix::io::RawFd;
 use std::result::Result;
 

--- a/src/vmm/src/utils/mod.rs
+++ b/src/vmm/src/utils/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod byte_order;
 pub mod memory;
 pub mod mock_resources;

--- a/src/vmm/src/utils/util.rs
+++ b/src/vmm/src/utils/util.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub use utils::errno;
 
 pub fn get_page_size() -> Result<usize, errno::Error> {

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -1,3 +1,9 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::arch;
 use serde::{Deserialize, Serialize};
 use std::fs::File;

--- a/src/vmm/src/vmm_config/drive.rs
+++ b/src/vmm/src/vmm_config/drive.rs
@@ -1,3 +1,9 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -1,3 +1,9 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_MEM_SIZE_MIB: usize = 128;

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -1,3 +1,9 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Wrapper for configuring the vm boot source.
 pub mod boot_source;
 /// Wrapper for configuring the block devices.

--- a/src/vmm/src/vstate/memory.rs
+++ b/src/vmm/src/vstate/memory.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::utils::util::get_page_size;
 use std::os::unix::io::AsRawFd;
 use vm_memory::{

--- a/src/vmm/src/vstate/mod.rs
+++ b/src/vmm/src/vstate/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod memory;
 pub mod vcpu;
 pub mod vm;

--- a/src/vmm/src/vstate/vcpu/mod.rs
+++ b/src/vmm/src/vstate/vcpu/mod.rs
@@ -1,3 +1,13 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
 pub mod x86_64;
 
 use crate::{

--- a/src/vmm/src/vstate/vcpu/x86_64.rs
+++ b/src/vmm/src/vstate/vcpu/x86_64.rs
@@ -1,3 +1,13 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
 use crate::{
     arch, cpu,
     vstate::{memory::GuestMemoryMmap, vm::Vm},

--- a/src/vmm/src/vstate/vm.rs
+++ b/src/vmm/src/vstate/vm.rs
@@ -1,3 +1,13 @@
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
 use crate::{arch, vstate::memory::GuestMemoryMmap};
 use kvm_bindings::{
     kvm_pit_config, kvm_userspace_memory_region, CpuId, KVM_MAX_CPUID_ENTRIES,
@@ -40,7 +50,7 @@ pub enum VmError {
     // VmFd(kvm_ioctls::Error),
     // // Failed to get mmap size
     // VcpuMmapSize(kvm_ioctls::Error),
-    /// Cannot set memory region.  
+    /// Cannot set memory region.
     #[error("Cannot set memory resion: {0}")]
     SetUserMemoryRegion(kvm_ioctls::Error),
 }

--- a/src/vmm/src/vstate/vm_control.rs
+++ b/src/vmm/src/vstate/vm_control.rs
@@ -1,4 +1,7 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright 2023 aztecher, or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
The following changes were made to comply with the Apache-2.0 license

- Changes to use vmm-sys-config epoll implementation instead of epoll crate to delete MPL-2 dependency.
- Creation of required files such as LICENSE, NOTICE, ...etc.
- Include a Copyright header in each source code

 We also checked for any license violations by using FOSSA.

